### PR TITLE
Basic Spring hygiene

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,24 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<groupId>org.openrewrite.maven</groupId>
+					<artifactId>rewrite-maven-plugin</artifactId>
+					<version>2.0.0-SNAPSHOT</version>
+					<configuration>
+						<activeRecipes>
+							<recipe>org.openrewrite.spring</recipe>
+						</activeRecipes>
+						<sourceTypes>
+							<type>java</type>
+						</sourceTypes>
+						<activeStyles>
+							<style>io.moderne.spring.style</style>
+						</activeStyles>
+						<metricsUri>LOG</metricsUri>
+						<configLocation>${maven.multiModuleProjectDirectory}/rewrite.yml</configLocation>
+					</configuration>
+				</plugin>
+				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.1</version>
 					<executions>

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,0 +1,19 @@
+---
+type: specs.openrewrite.org/v1beta/style
+name: io.moderne.spring.style
+
+configure:
+  org.openrewrite.java.style.ImportLayoutStyle:
+    layout:
+      classCountToUseStarImport: 999
+      nameCountToUseStarImport: 999
+      blocks:
+        - import java.*
+        - <blank line>
+        - import javax.*
+        - <blank line>
+        - import all other imports
+        - <blank line>
+        - import org.springframework.*
+        - <blank line>
+        - import static all other imports

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncDefaultAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncDefaultAutoConfiguration.java
@@ -61,13 +61,13 @@ class AsyncDefaultAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled",
 			matchIfMissing = true)
-	public static ExecutorBeanPostProcessor executorBeanPostProcessor(
+	static ExecutorBeanPostProcessor executorBeanPostProcessor(
 			BeanFactory beanFactory) {
 		return new ExecutorBeanPostProcessor(beanFactory);
 	}
 
 	@Bean
-	public TraceAsyncAspect traceAsyncAspect(Tracer tracer, SpanNamer spanNamer) {
+	TraceAsyncAspect traceAsyncAspect(Tracer tracer, SpanNamer spanNamer) {
 		return new TraceAsyncAspect(tracer, spanNamer);
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/grpc/TraceGrpcAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/grpc/TraceGrpcAutoConfiguration.java
@@ -48,7 +48,7 @@ import org.springframework.context.annotation.Bean;
 class TraceGrpcAutoConfiguration {
 
 	@Bean
-	public GrpcTracing grpcTracing(RpcTracing rpcTracing) {
+	GrpcTracing grpcTracing(RpcTracing rpcTracing) {
 		return GrpcTracing.create(rpcTracing);
 	}
 
@@ -62,7 +62,7 @@ class TraceGrpcAutoConfiguration {
 	// This is wrapper around gRPC's managed channel builder that is spring-aware
 	@Bean
 	@ConditionalOnMissingBean(SpringAwareManagedChannelBuilder.class)
-	public SpringAwareManagedChannelBuilder managedChannelBuilder(
+	SpringAwareManagedChannelBuilder managedChannelBuilder(
 			Optional<List<GrpcManagedChannelBuilderCustomizer>> customizers) {
 		return new SpringAwareManagedChannelBuilder(customizers);
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceSpringIntegrationAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceSpringIntegrationAutoConfiguration.java
@@ -59,7 +59,7 @@ import org.springframework.util.ObjectUtils;
 class TraceSpringIntegrationAutoConfiguration {
 
 	@Bean
-	public GlobalChannelInterceptorWrapper tracingGlobalChannelInterceptorWrapper(
+	GlobalChannelInterceptorWrapper tracingGlobalChannelInterceptorWrapper(
 			TracingChannelInterceptor interceptor, SleuthMessagingProperties properties) {
 		GlobalChannelInterceptorWrapper wrapper = new GlobalChannelInterceptorWrapper(
 				interceptor);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TracingChannelInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TracingChannelInterceptor.java
@@ -107,7 +107,6 @@ final class TracingChannelInterceptor extends ChannelInterceptorAdapter
 	// special case of a Stream
 	private final Class<?> directWithAttributesChannelClass;
 
-	@Autowired
 	TracingChannelInterceptor(Tracing tracing, SleuthMessagingProperties properties) {
 		this(tracing, properties, MessageHeaderPropagation.INSTANCE,
 				MessageHeaderPropagation.INSTANCE);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/quartz/TraceQuartzAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/quartz/TraceQuartzAutoConfiguration.java
@@ -56,7 +56,7 @@ class TraceQuartzAutoConfiguration implements InitializingBean {
 	BeanFactory beanFactory;
 
 	@Bean
-	public TracingJobListener tracingJobListener() {
+	TracingJobListener tracingJobListener() {
 		return new TracingJobListener(tracing);
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfiguration.java
@@ -47,7 +47,7 @@ import org.springframework.context.annotation.Configuration;
 class TraceSchedulingAutoConfiguration {
 
 	@Bean
-	public TraceSchedulingAspect traceSchedulingAspect(Tracer tracer,
+	TraceSchedulingAspect traceSchedulingAspect(Tracer tracer,
 			SleuthSchedulingProperties sleuthSchedulingProperties) {
 		String skipPatternString = sleuthSchedulingProperties.getSkipPattern();
 		Pattern skipPattern = skipPatternString != null

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternConfiguration.java
@@ -139,7 +139,7 @@ class SkipPatternConfiguration {
 
 		@Bean
 		@ConditionalOnBean(ManagementServerProperties.class)
-		public SingleSkipPattern skipPatternForManagementServerProperties(
+		SingleSkipPattern skipPatternForManagementServerProperties(
 				Environment environment,
 				final ManagementServerProperties managementServerProperties) {
 			return () -> getPatternForManagementServerProperties(environment,
@@ -212,7 +212,7 @@ class SkipPatternConfiguration {
 
 		@Bean
 		@ConditionalOnManagementPort(ManagementPortType.SAME)
-		public SingleSkipPattern skipPatternForActuatorEndpointsSamePort(
+		SingleSkipPattern skipPatternForActuatorEndpointsSamePort(
 				Environment environment, final ServerProperties serverProperties,
 				final WebEndpointProperties webEndpointProperties,
 				final EndpointsSupplier<ExposableWebEndpoint> endpointsSupplier) {
@@ -225,7 +225,7 @@ class SkipPatternConfiguration {
 		@ConditionalOnManagementPort(ManagementPortType.DIFFERENT)
 		@ConditionalOnProperty(name = "management.server.servlet.context-path",
 				havingValue = "/", matchIfMissing = true)
-		public SingleSkipPattern skipPatternForActuatorEndpointsDifferentPort(
+		SingleSkipPattern skipPatternForActuatorEndpointsDifferentPort(
 				Environment environment, final ServerProperties serverProperties,
 				final WebEndpointProperties webEndpointProperties,
 				final EndpointsSupplier<ExposableWebEndpoint> endpointsSupplier) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFluxAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFluxAutoConfiguration.java
@@ -41,7 +41,7 @@ import org.springframework.context.annotation.Configuration;
 class TraceWebFluxAutoConfiguration {
 
 	@Bean
-	public TraceWebFilter traceFilter(BeanFactory beanFactory) {
+	TraceWebFilter traceFilter(BeanFactory beanFactory) {
 		return new TraceWebFilter(beanFactory);
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebServletAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebServletAutoConfiguration.java
@@ -74,7 +74,7 @@ class TraceWebServletAutoConfiguration {
 	}
 
 	@Bean
-	public FilterRegistrationBean traceWebFilter(BeanFactory beanFactory,
+	FilterRegistrationBean traceWebFilter(BeanFactory beanFactory,
 			SleuthWebProperties webProperties) {
 		FilterRegistrationBean filterRegistrationBean = new FilterRegistrationBean(
 				new LazyTracingFilter(beanFactory));
@@ -87,7 +87,7 @@ class TraceWebServletAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public TracingFilter tracingFilter(HttpTracing tracing) {
+	TracingFilter tracingFilter(HttpTracing tracing) {
 		return (TracingFilter) TracingFilter.create(tracing);
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfiguration.java
@@ -59,7 +59,7 @@ class TraceWebAsyncClientAutoConfiguration {
 	static class AsyncRestTemplateConfig {
 
 		@Bean
-		public TracingAsyncClientHttpRequestInterceptor asyncTracingClientHttpRequestInterceptor(
+		TracingAsyncClientHttpRequestInterceptor asyncTracingClientHttpRequestInterceptor(
 				HttpTracing httpTracing) {
 			return (TracingAsyncClientHttpRequestInterceptor) TracingAsyncClientHttpRequestInterceptor
 					.create(httpTracing);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
@@ -75,7 +75,7 @@ class TraceWebClientAutoConfiguration {
 	static class RestTemplateConfig {
 
 		@Bean
-		public TracingClientHttpRequestInterceptor tracingClientHttpRequestInterceptor(
+		TracingClientHttpRequestInterceptor tracingClientHttpRequestInterceptor(
 				HttpTracing httpTracing) {
 			return (TracingClientHttpRequestInterceptor) TracingClientHttpRequestInterceptor
 					.create(httpTracing);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/SamplerAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/SamplerAutoConfiguration.java
@@ -69,7 +69,7 @@ public class SamplerAutoConfiguration {
 		@ConditionalOnMissingBean
 		@ConditionalOnProperty(value = "spring.sleuth.sampler.refresh.enabled",
 				matchIfMissing = true)
-		public Sampler defaultTraceSampler(SamplerProperties config) {
+		Sampler defaultTraceSampler(SamplerProperties config) {
 			return sampler(config);
 		}
 
@@ -77,7 +77,7 @@ public class SamplerAutoConfiguration {
 		@ConditionalOnMissingBean
 		@ConditionalOnProperty(value = "spring.sleuth.sampler.refresh.enabled",
 				havingValue = "false")
-		public Sampler defaultNonRefreshScopeTraceSampler(SamplerProperties config) {
+		Sampler defaultNonRefreshScopeTraceSampler(SamplerProperties config) {
 			return sampler(config);
 		}
 
@@ -101,7 +101,7 @@ public class SamplerAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public Sampler defaultTraceSampler(SamplerProperties config) {
+		Sampler defaultTraceSampler(SamplerProperties config) {
 			return samplerFromProps(config);
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/NullSpanTagAnnotationHandlerTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/NullSpanTagAnnotationHandlerTests.java
@@ -104,7 +104,7 @@ public class NullSpanTagAnnotationHandlerTests {
 	protected static class TestConfiguration {
 
 		@Bean
-		public TagValueResolver tagValueResolver() {
+		TagValueResolver tagValueResolver() {
 			return parameter -> null;
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectFluxTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectFluxTests.java
@@ -621,7 +621,7 @@ public class SleuthSpanCreatorAspectFluxTests {
 	protected static class TestConfiguration {
 
 		@Bean
-		public TestBeanInterface testBean(Tracer tracer) {
+		TestBeanInterface testBean(Tracer tracer) {
 			return new TestBean(tracer);
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectMonoTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectMonoTests.java
@@ -663,12 +663,12 @@ public class SleuthSpanCreatorAspectMonoTests {
 	protected static class TestConfiguration {
 
 		@Bean
-		public TestBeanInterface testBean(Tracer tracer) {
+		TestBeanInterface testBean(Tracer tracer) {
 			return new TestBean(tracer);
 		}
 
 		@Bean
-		public TestBeanOuter testBeanOuter(Tracer tracer, TestBeanInterface testBean) {
+		TestBeanOuter testBeanOuter(Tracer tracer, TestBeanInterface testBean) {
 			return new TestBeanOuter(tracer, testBean);
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectNegativeTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectNegativeTests.java
@@ -143,17 +143,17 @@ public class SleuthSpanCreatorAspectNegativeTests {
 		}
 
 		@Bean
-		public NotAnnotatedTestBeanInterface testBean() {
+		NotAnnotatedTestBeanInterface testBean() {
 			return new NotAnnotatedTestBean();
 		}
 
 		@Bean
-		public TestBeanInterface annotatedTestBean() {
+		TestBeanInterface annotatedTestBean() {
 			return new TestBean();
 		}
 
 		@Bean
-		public Sampler sampler() {
+		Sampler sampler() {
 			return Sampler.ALWAYS_SAMPLE;
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectTests.java
@@ -403,7 +403,7 @@ public class SleuthSpanCreatorAspectTests {
 	protected static class TestConfiguration {
 
 		@Bean
-		public TestBeanInterface testBean() {
+		TestBeanInterface testBean() {
 			return new TestBean();
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorCircularDependencyTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorCircularDependencyTests.java
@@ -66,12 +66,12 @@ public class SleuthSpanCreatorCircularDependencyTests {
 		}
 
 		@Bean
-		public Service1 service1() {
+		Service1 service1() {
 			return new Service1();
 		}
 
 		@Bean
-		public Service2 service2() {
+		Service2 service2() {
 			return new Service2();
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SpanTagAnnotationHandlerTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SpanTagAnnotationHandlerTests.java
@@ -104,7 +104,7 @@ public class SpanTagAnnotationHandlerTests {
 
 		// tag::custom_resolver[]
 		@Bean(name = "myCustomTagValueResolver")
-		public TagValueResolver tagValueResolver() {
+		TagValueResolver tagValueResolver() {
 			return parameter -> "Value from myCustomTagValueResolver";
 		}
 		// end::custom_resolver[]

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
@@ -74,7 +74,7 @@ public class TraceAutoConfigurationPropagationCustomizationTests {
 	static class CustomPropagationFactoryBuilderConfig {
 
 		@Bean
-		public BaggagePropagation.FactoryBuilder b3Single() {
+		BaggagePropagation.FactoryBuilder b3Single() {
 			return BaggagePropagation.newFactoryBuilder(B3SinglePropagation.FACTORY);
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationTests.java
@@ -144,7 +144,6 @@ public class TraceAutoConfigurationTests {
 
 		List<BaggageField> fields;
 
-		@Autowired
 		Baggage(Tracing tracing) {
 			// When predefined baggage fields exist, the result !=
 			// TraceContextOrSamplingFlags.EMPTY

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/baggage/BaggageTagSpanHandlerTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/baggage/BaggageTagSpanHandlerTest.java
@@ -79,7 +79,7 @@ public class BaggageTagSpanHandlerTest {
 	static class Config {
 
 		@Bean
-		public SpanHandler testSpanHandler() {
+		SpanHandler testSpanHandler() {
 			return new TestSpanHandler();
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/documentation/SpringCloudSleuthDocTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/documentation/SpringCloudSleuthDocTests.java
@@ -288,7 +288,7 @@ public class SpringCloudSleuthDocTests {
 
 		// tag::always_sampler[]
 		@Bean
-		public Sampler defaultSampler() {
+		Sampler defaultSampler() {
 			return Sampler.ALWAYS_SAMPLE;
 		}
 		// end::always_sampler[]

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/AsyncDefaultAutoConfigurationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/AsyncDefaultAutoConfigurationTests.java
@@ -45,7 +45,7 @@ public class AsyncDefaultAutoConfigurationTests {
 	static class Config {
 
 		@Bean
-		public ScheduledExecutorService createExecutorService() {
+		ScheduledExecutorService createExecutorService() {
 			return Executors.newSingleThreadScheduledExecutor();
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/AsyncDisabledTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/AsyncDisabledTests.java
@@ -65,7 +65,7 @@ public class AsyncDisabledTests {
 
 		@Bean
 		@ConditionalOnMissingBean(name = "traceSenderThreadPool")
-		public ThreadPoolTaskScheduler traceSenderThreadPool() {
+		ThreadPoolTaskScheduler traceSenderThreadPool() {
 			return new ThreadPoolTaskScheduler();
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/multiple/DemoApplication.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/multiple/DemoApplication.java
@@ -35,8 +35,8 @@ import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.annotation.Splitter;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -71,7 +71,7 @@ public class DemoApplication {
 	@Autowired
 	Tracer tracer;
 
-	@RequestMapping("/greeting")
+	@GetMapping("/greeting")
 	public Greeting greeting(@RequestParam(defaultValue = "Hello World!") String message,
 			@RequestHeader HttpHeaders headers) {
 		this.sender.send(message);

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/quartz/TraceQuartzAutoConfigurationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/quartz/TraceQuartzAutoConfigurationTest.java
@@ -112,7 +112,7 @@ public class TraceQuartzAutoConfigurationTest {
 	public static class SchedulerConfig {
 
 		@Bean
-		public Scheduler scheduler() throws Exception {
+		Scheduler scheduler() throws Exception {
 			Scheduler scheduler = mock(Scheduler.class);
 			when(scheduler.getListenerManager()).thenReturn(mock(ListenerManager.class));
 			return scheduler;
@@ -125,12 +125,12 @@ public class TraceQuartzAutoConfigurationTest {
 	public static class TracingConfig {
 
 		@Bean
-		public Tracing tracing() {
+		Tracing tracing() {
 			return mock(Tracing.class);
 		}
 
 		@Bean
-		public Tracer tracer() {
+		Tracer tracer() {
 			return mock(Tracer.class);
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/EndpointWithCyclicDependenciesTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/EndpointWithCyclicDependenciesTests.java
@@ -48,7 +48,7 @@ public class EndpointWithCyclicDependenciesTests {
 	static class ClientConfig {
 
 		@Bean
-		public Client client(HttpTracing httpTracing) {
+		Client client(HttpTracing httpTracing) {
 			// imagine this instruments the client.
 			return new Client();
 		}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceNoWebEnvironmentTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceNoWebEnvironmentTests.java
@@ -26,8 +26,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -60,7 +59,7 @@ public class TraceNoWebEnvironmentTests {
 		@FeignClient(name = "google", url = "https://www.google.com/")
 		public interface SomeFeignClient {
 
-			@RequestMapping(value = "/", method = RequestMethod.GET)
+			@GetMapping("/")
 			String createSomeTestRequest();
 
 		}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceRestTemplateInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceRestTemplateInterceptorTests.java
@@ -40,8 +40,8 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.test.web.client.MockMvcClientHttpRequestFactory;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
@@ -202,7 +202,7 @@ public class TraceRestTemplateInterceptorTests {
 
 		Span span;
 
-		@RequestMapping("/")
+		@GetMapping("/")
 		public Map<String, String> home(@RequestHeader HttpHeaders headers) {
 			this.span = TraceRestTemplateInterceptorTests.this.tracer.currentSpan();
 			Map<String, String> map = new HashMap<>();
@@ -211,11 +211,11 @@ public class TraceRestTemplateInterceptorTests {
 			return map;
 		}
 
-		@RequestMapping("/foo")
+		@GetMapping("/foo")
 		public void foo() {
 		}
 
-		@RequestMapping("/exception")
+		@GetMapping("/exception")
 		public Map<String, String> exception() {
 			throw new RuntimeException("foo");
 		}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/GH846Tests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/GH846Tests.java
@@ -50,12 +50,12 @@ public class GH846Tests {
 	static class App {
 
 		@Bean
-		public RestTemplate myRestTemplate() {
+		RestTemplate myRestTemplate() {
 			return new RestTemplate();
 		}
 
 		@Bean
-		public MyBean myBean() {
+		MyBean myBean() {
 			return new MyBean();
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/MultipleAsyncRestTemplateTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/MultipleAsyncRestTemplateTests.java
@@ -54,7 +54,7 @@ import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.AsyncRestTemplate;
 
@@ -158,7 +158,7 @@ public class MultipleAsyncRestTemplateTests {
 	static class Config {
 
 		@Bean(name = "customAsyncRestTemplate")
-		public AsyncRestTemplate traceAsyncRestTemplate() {
+		AsyncRestTemplate traceAsyncRestTemplate() {
 			return new AsyncRestTemplate(asyncClientFactory(),
 					clientHttpRequestFactory());
 		}
@@ -259,7 +259,7 @@ class MyRestController {
 		this.tracer = tracer;
 	}
 
-	@RequestMapping("/foo")
+	@GetMapping("/foo")
 	String foo() {
 		return this.tracer.currentSpan().context().traceIdString();
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/discoveryexception/WebClientDiscoveryExceptionTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/discoveryexception/WebClientDiscoveryExceptionTests.java
@@ -48,8 +48,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -116,7 +115,7 @@ public class WebClientDiscoveryExceptionTests {
 	@FeignClient("exceptionservice")
 	public interface TestFeignInterfaceWithException {
 
-		@RequestMapping(method = RequestMethod.GET, value = "/")
+		@GetMapping("/")
 		ResponseEntity<String> shouldFailToConnect();
 
 	}
@@ -139,7 +138,7 @@ public class WebClientDiscoveryExceptionTests {
 
 		@LoadBalanced
 		@Bean
-		public RestTemplate restTemplate() {
+		RestTemplate restTemplate() {
 			return new RestTemplate();
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exception/WebClientExceptionTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exception/WebClientExceptionTests.java
@@ -45,8 +45,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.fail;
@@ -112,7 +111,7 @@ public class WebClientExceptionTests {
 	@FeignClient("exceptionservice")
 	public interface TestFeignInterfaceWithException {
 
-		@RequestMapping(method = RequestMethod.GET, value = "/")
+		@GetMapping("/")
 		ResponseEntity<String> shouldFailToConnect();
 
 	}
@@ -133,7 +132,7 @@ public class WebClientExceptionTests {
 
 		@LoadBalanced
 		@Bean
-		public RestTemplate restTemplate() {
+		RestTemplate restTemplate() {
 			SimpleClientHttpRequestFactory clientHttpRequestFactory = new SimpleClientHttpRequestFactory();
 			clientHttpRequestFactory.setReadTimeout(1);
 			clientHttpRequestFactory.setConnectTimeout(1);
@@ -156,7 +155,7 @@ public class WebClientExceptionTests {
 	public static class ExceptionServiceLoadBalancerClientConfiguration {
 
 		@Bean
-		public ServiceInstanceListSupplier serviceInstanceListSupplier(Environment env) {
+		ServiceInstanceListSupplier serviceInstanceListSupplier(Environment env) {
 			return ServiceInstanceListSupplier.fixed(env)
 					.instance("invalid.host.to.break.tests", 1234, "exceptionservice")
 					.build();

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
@@ -83,9 +83,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
@@ -492,16 +491,16 @@ public class WebClientTests {
 	@FeignClient("fooservice")
 	public interface TestFeignInterface {
 
-		@RequestMapping(method = RequestMethod.GET, value = "/traceid")
+		@GetMapping("/traceid")
 		ResponseEntity<String> getTraceId();
 
-		@RequestMapping(method = RequestMethod.GET, value = "/notrace")
+		@GetMapping("/notrace")
 		ResponseEntity<String> getNoTrace();
 
-		@RequestMapping(method = RequestMethod.GET, value = "/")
+		@GetMapping("/")
 		ResponseEntity<Map<String, String>> headers();
 
-		@RequestMapping(method = RequestMethod.GET, value = "/noresponse")
+		@GetMapping("/noresponse")
 		ResponseEntity<Void> noResponseBody();
 
 	}
@@ -543,7 +542,7 @@ public class WebClientTests {
 
 		@LoadBalanced
 		@Bean
-		public RestTemplate restTemplate() {
+		RestTemplate restTemplate() {
 			return new RestTemplate();
 		}
 
@@ -627,22 +626,22 @@ public class WebClientTests {
 
 		Span span;
 
-		@RequestMapping(value = "/notrace", method = RequestMethod.GET)
+		@GetMapping("/notrace")
 		public String notrace(
-				@RequestHeader(name = "b3", required = false) String b3Single) {
-			then(b3Single).isNotNull();
+				@RequestHeader(required = false) String b3) {
+			then(b3).isNotNull();
 			return "OK";
 		}
 
-		@RequestMapping(value = "/traceid", method = RequestMethod.GET)
-		public String traceId(@RequestHeader("b3") String b3Single) {
+		@GetMapping("/traceid")
+		public String traceId(@RequestHeader String b3) {
 			TraceContextOrSamplingFlags traceContext = B3SingleFormat
-					.parseB3SingleFormat(b3Single);
+					.parseB3SingleFormat(b3);
 			then(traceContext.context()).isNotNull();
-			return b3Single;
+			return b3;
 		}
 
-		@RequestMapping("/")
+		@GetMapping("/")
 		public Map<String, String> home(@RequestHeader HttpHeaders headers) {
 			Map<String, String> map = new HashMap<>();
 			for (String key : headers.keySet()) {
@@ -651,10 +650,10 @@ public class WebClientTests {
 			return map;
 		}
 
-		@RequestMapping("/noresponse")
-		public void noResponse(@RequestHeader("b3") String b3Single) {
+		@GetMapping("/noresponse")
+		public void noResponse(@RequestHeader String b3) {
 			TraceContextOrSamplingFlags traceContext = B3SingleFormat
-					.parseB3SingleFormat(b3Single);
+					.parseB3SingleFormat(b3);
 			then(traceContext.context()).isNotNull();
 		}
 
@@ -671,13 +670,13 @@ public class WebClientTests {
 	@RestController
 	public static class WebClientController {
 
-		@RequestMapping(value = "/issue1462", method = RequestMethod.GET)
+		@GetMapping("/issue1462")
 		public ResponseEntity<String> issue1462() {
 			System.out.println("GOT IT");
 			return ResponseEntity.status(499).body("issue1462");
 		}
 
-		@RequestMapping(value = { "/skip", "/doNotSkip" }, method = RequestMethod.GET)
+		@GetMapping({ "/skip", "/doNotSkip" })
 		String skip() {
 			return "ok";
 		}
@@ -691,7 +690,7 @@ public class WebClientTests {
 		private int port = 0;
 
 		@Bean
-		public ServiceInstanceListSupplier serviceInstanceListSupplier(Environment env) {
+		ServiceInstanceListSupplier serviceInstanceListSupplier(Environment env) {
 			return ServiceInstanceListSupplier.fixed(env)
 					.instance(this.port, "fooservice").build();
 		}

--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -35,6 +35,28 @@
 		<brave.opentracing.version>0.37.2</brave.opentracing.version>
 		<grpc.spring.boot.version>3.5.6</grpc.spring.boot.version>
 	</properties>
+	<build>
+		<plugins>
+			<plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>2.0.0-SNAPSHOT</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>org.openrewrite.spring</recipe>
+                    </activeRecipes>
+					<sourceTypes>
+						<type>java</type>
+					</sourceTypes>
+					<activeStyles>
+						<style>io.moderne.spring.style</style>
+					</activeStyles>
+                    <metricsUri>LOG</metricsUri>
+                    <configLocation>${maven.multiModuleProjectDirectory}/rewrite.yml</configLocation>
+                </configuration>
+            </plugin>
+		</plugins>
+	</build>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample/src/main/java/sample/SampleController.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample/src/main/java/sample/SampleController.java
@@ -27,7 +27,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.context.ServletWebServerInitializedEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
@@ -53,7 +53,7 @@ public class SampleController
 
 	private int port;
 
-	@RequestMapping("/")
+	@GetMapping("/")
 	public String hi() throws InterruptedException {
 		log.info("hi!");
 		Thread.sleep(this.random.nextInt(1000));
@@ -63,7 +63,7 @@ public class SampleController
 		return "hi/" + s;
 	}
 
-	@RequestMapping("/call")
+	@GetMapping("/call")
 	public Callable<String> call() {
 		return new Callable<String>() {
 			@Override
@@ -79,14 +79,14 @@ public class SampleController
 		};
 	}
 
-	@RequestMapping("/async")
+	@GetMapping("/async")
 	public String async() throws InterruptedException {
 		log.info("async");
 		this.controller.background();
 		return "ho";
 	}
 
-	@RequestMapping("/hi2")
+	@GetMapping("/hi2")
 	public String hi2() throws InterruptedException {
 		log.info("hi2!");
 		int millis = this.random.nextInt(1000);
@@ -95,7 +95,7 @@ public class SampleController
 		return "hi2";
 	}
 
-	@RequestMapping("/traced")
+	@GetMapping("/traced")
 	public String traced() throws InterruptedException {
 		log.info("traced");
 		Span span = this.tracer.nextSpan().name("http:customTraceEndpoint");
@@ -110,7 +110,7 @@ public class SampleController
 		return "traced/" + s;
 	}
 
-	@RequestMapping("/start")
+	@GetMapping("/start")
 	public String start() throws InterruptedException {
 		log.info("start");
 		int millis = this.random.nextInt(1000);

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample/src/main/java/sample/SampleSleuthApplication.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample/src/main/java/sample/SampleSleuthApplication.java
@@ -36,12 +36,12 @@ public class SampleSleuthApplication {
 	}
 
 	@Bean
-	public RestTemplate restTemplate() {
+	RestTemplate restTemplate() {
 		return new RestTemplate();
 	}
 
 	@Bean
-	public Sampler sampler() {
+	Sampler sampler() {
 		return Sampler.ALWAYS_SAMPLE;
 	}
 

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfiguration.java
@@ -119,7 +119,7 @@ public class ZipkinAutoConfiguration {
 
 	@Bean(REPORTER_BEAN_NAME)
 	@ConditionalOnMissingBean(name = REPORTER_BEAN_NAME)
-	public Reporter<Span> reporter(ReporterMetrics reporterMetrics,
+	Reporter<Span> reporter(ReporterMetrics reporterMetrics,
 			ZipkinProperties zipkin, @Qualifier(SENDER_BEAN_NAME) Sender sender) {
 		CheckResult checkResult = checkResult(sender, 1_000L);
 		logCheckResult(sender, checkResult);
@@ -214,7 +214,7 @@ public class ZipkinAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ZipkinRestTemplateCustomizer zipkinRestTemplateCustomizer(
+	ZipkinRestTemplateCustomizer zipkinRestTemplateCustomizer(
 			ZipkinProperties zipkinProperties) {
 		return new DefaultZipkinRestTemplateCustomizer(zipkinProperties);
 	}
@@ -238,7 +238,7 @@ public class ZipkinAutoConfiguration {
 		private Environment environment;
 
 		@Bean
-		public EndpointLocator zipkinEndpointLocator() {
+		EndpointLocator zipkinEndpointLocator() {
 			return new DefaultEndpointLocator(null, this.serverProperties,
 					this.environment, this.zipkinProperties, this.inetUtils);
 		}
@@ -268,7 +268,7 @@ public class ZipkinAutoConfiguration {
 		private Registration registration;
 
 		@Bean
-		public EndpointLocator zipkinEndpointLocator() {
+		EndpointLocator zipkinEndpointLocator() {
 			return new DefaultEndpointLocator(this.registration, this.serverProperties,
 					this.environment, this.zipkinProperties, this.inetUtils);
 		}

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinRestTemplateSenderConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinRestTemplateSenderConfiguration.java
@@ -59,7 +59,7 @@ class ZipkinRestTemplateSenderConfiguration {
 	ZipkinUrlExtractor extractor;
 
 	@Bean(ZipkinAutoConfiguration.SENDER_BEAN_NAME)
-	public Sender restTemplateSender(ZipkinProperties zipkin,
+	Sender restTemplateSender(ZipkinProperties zipkin,
 			ZipkinRestTemplateCustomizer zipkinRestTemplateCustomizer) {
 		RestTemplate restTemplate = new ZipkinRestTemplateWrapper(zipkin, this.extractor);
 		restTemplate = zipkinRestTemplateCustomizer.customizeTemplate(restTemplate);

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/DefaultEndpointLocatorConfigurationTest.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/DefaultEndpointLocatorConfigurationTest.java
@@ -188,7 +188,7 @@ public class DefaultEndpointLocatorConfigurationTest {
 	public static class ConfigurationWithRegistration {
 
 		@Bean
-		public Registration getRegistration() {
+		Registration getRegistration() {
 			return new Registration() {
 				@Override
 				public String getServiceId() {
@@ -231,7 +231,7 @@ public class DefaultEndpointLocatorConfigurationTest {
 		static EndpointLocator locator = Mockito.mock(EndpointLocator.class);
 
 		@Bean
-		public EndpointLocator getEndpointLocator() {
+		EndpointLocator getEndpointLocator() {
 			return locator;
 		}
 

--- a/tests/spring-cloud-sleuth-instrumentation-async-tests/src/test/java/org/springframework/cloud/sleuth/instrument/async/issues/issue1212/GH1212Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-async-tests/src/test/java/org/springframework/cloud/sleuth/instrument/async/issues/issue1212/GH1212Tests.java
@@ -121,7 +121,7 @@ public class GH1212Tests {
 	static class DefaultTaskExecutorConfig {
 
 		@Bean(name = AsyncExecutionAspectSupport.DEFAULT_TASK_EXECUTOR_BEAN_NAME)
-		public Executor taskExecutor() {
+		Executor taskExecutor() {
 			return new SimpleAsyncTaskExecutor("defaultTaskExecutor");
 		}
 
@@ -136,7 +136,7 @@ public class GH1212Tests {
 		@Bean
 		// there's the task
 		@Primary
-		public TaskExecutor singleTaskExecutor() {
+		TaskExecutor singleTaskExecutor() {
 			return new SimpleAsyncTaskExecutor("singleTaskExecutor");
 		}
 
@@ -150,12 +150,12 @@ public class GH1212Tests {
 	static class MultipleTaskExecutorConfig {
 
 		@Bean
-		public TaskExecutor multipleTaskExecutor1() {
+		TaskExecutor multipleTaskExecutor1() {
 			return new SimpleAsyncTaskExecutor("multipleTaskExecutor1");
 		}
 
 		@Bean
-		public TaskExecutor multipleTaskExecutor2() {
+		TaskExecutor multipleTaskExecutor2() {
 			return new SimpleAsyncTaskExecutor("multipleTaskExecutor2");
 		}
 
@@ -168,7 +168,7 @@ public class GH1212Tests {
 	static class CustomAsyncConfigurerConfig {
 
 		@Bean
-		public AsyncConfigurer customAsyncConfigurer() {
+		AsyncConfigurer customAsyncConfigurer() {
 			return new AsyncConfigurerSupport() {
 				@Override
 				public Executor getAsyncExecutor() {

--- a/tests/spring-cloud-sleuth-instrumentation-async-tests/src/test/java/org/springframework/cloud/sleuth/instrument/async/issues/issue410/Issue410Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-async-tests/src/test/java/org/springframework/cloud/sleuth/instrument/async/issues/issue410/Issue410Tests.java
@@ -48,7 +48,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
@@ -261,36 +261,36 @@ public class Issue410Tests {
 class AppConfig {
 
 	@Bean
-	public Sampler testSampler() {
+	Sampler testSampler() {
 		return Sampler.ALWAYS_SAMPLE;
 	}
 
 	@Bean
-	public RestTemplate restTemplate() {
+	RestTemplate restTemplate() {
 		return new RestTemplate();
 	}
 
 	@Bean("taskScheduler")
-	public Executor myScheduler() {
+	Executor myScheduler() {
 		return Executors.newSingleThreadExecutor();
 	}
 
 	@Bean
-	public Executor poolTaskExecutor() {
+	Executor poolTaskExecutor() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 		executor.initialize();
 		return executor;
 	}
 
 	@Bean
-	public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
+	ThreadPoolTaskScheduler threadPoolTaskScheduler() {
 		ThreadPoolTaskScheduler executor = new ThreadPoolTaskScheduler();
 		executor.initialize();
 		return executor;
 	}
 
 	@Bean
-	public ScheduledThreadPoolExecutor scheduledThreadPoolExecutor() {
+	ScheduledThreadPoolExecutor scheduledThreadPoolExecutor() {
 		return new ScheduledThreadPoolExecutor(10);
 	}
 
@@ -435,7 +435,7 @@ class Application {
 	@Autowired
 	Tracer tracer;
 
-	@RequestMapping("/with_pool")
+	@GetMapping("/with_pool")
 	public String withPool() {
 		log.info("Executing with pool.");
 		this.asyncTask.runWithPool();
@@ -443,40 +443,40 @@ class Application {
 
 	}
 
-	@RequestMapping("/without_pool")
+	@GetMapping("/without_pool")
 	public String withoutPool() {
 		log.info("Executing without pool.");
 		this.asyncTask.runWithoutPool();
 		return this.tracer.currentSpan().context().traceIdString();
 	}
 
-	@RequestMapping("/completable")
+	@GetMapping("/completable")
 	public String completable() throws ExecutionException, InterruptedException {
 		log.info("Executing completable");
 		return this.asyncTask.completableFutures().context().traceIdString();
 	}
 
-	@RequestMapping("/taskScheduler")
+	@GetMapping("/taskScheduler")
 	public String taskScheduler() throws ExecutionException, InterruptedException {
 		log.info("Executing completable via task scheduler");
 		return this.asyncTask.taskScheduler().context().traceIdString();
 	}
 
-	@RequestMapping("/threadPoolTaskScheduler_submit")
+	@GetMapping("/threadPoolTaskScheduler_submit")
 	public String threadPoolTaskSchedulerSubmit()
 			throws ExecutionException, InterruptedException {
 		log.info("Executing completable via ThreadPoolTaskScheduler");
 		return this.asyncTask.threadPoolTaskSchedulerSubmit().context().traceIdString();
 	}
 
-	@RequestMapping("/threadPoolTaskScheduler_schedule")
+	@GetMapping("/threadPoolTaskScheduler_schedule")
 	public String threadPoolTaskSchedulerSchedule()
 			throws ExecutionException, InterruptedException {
 		log.info("Executing completable via ThreadPoolTaskScheduler");
 		return this.asyncTask.threadPoolTaskSchedulerSchedule().context().traceIdString();
 	}
 
-	@RequestMapping("/scheduledThreadPoolExecutor")
+	@GetMapping("/scheduledThreadPoolExecutor")
 	public String scheduledThreadPoolExecutor()
 			throws ExecutionException, InterruptedException {
 		log.info("Executing completable via ScheduledThreadPoolExecutor");
@@ -488,7 +488,7 @@ class Application {
 	 * @return service bean
 	 */
 	@Bean
-	public MyService executorService() {
+	MyService executorService() {
 		return new MyService() {
 			@Override
 			public void execute(Runnable command) {

--- a/tests/spring-cloud-sleuth-instrumentation-async-tests/src/test/java/org/springframework/cloud/sleuth/instrument/async/issues/issue546/Issue546Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-async-tests/src/test/java/org/springframework/cloud/sleuth/instrument/async/issues/issue546/Issue546Tests.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.AsyncRestTemplate;
@@ -87,13 +87,13 @@ class Controller {
 		this.tracer = tracer;
 	}
 
-	@RequestMapping("/bean")
+	@GetMapping("/bean")
 	public HogeBean bean() {
 		log.info("(/bean) I got a request!");
 		return new HogeBean("test", 18);
 	}
 
-	@RequestMapping("/trace-async-rest-template")
+	@GetMapping("/trace-async-rest-template")
 	public void asyncTest(@RequestParam(required = false) boolean isSleep)
 			throws InterruptedException {
 		log.info("(/trace-async-rest-template) I got a request!");

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125/ManuallyCreatedLoadBalancerFeignClientTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125/ManuallyCreatedLoadBalancerFeignClientTests.java
@@ -44,8 +44,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -101,23 +100,23 @@ public class ManuallyCreatedLoadBalancerFeignClientTests {
 class Application {
 
 	@Bean
-	public Client client(LoadBalancerClient blockingLoadBalancerClient) {
+	Client client(LoadBalancerClient blockingLoadBalancerClient) {
 		return new MyBlockingClient(new MyDelegateClient(), blockingLoadBalancerClient);
 	}
 
 	@Bean
-	public Sampler defaultSampler() {
+	Sampler defaultSampler() {
 		return Sampler.ALWAYS_SAMPLE;
 	}
 
 	@Bean
-	public SpanHandler testSpanHandler() {
+	SpanHandler testSpanHandler() {
 		return new TestSpanHandler();
 	}
 
 	@Bean(name = HttpClientSampler.NAME)
 	@HttpClientSampler
-	public SamplerFunction<HttpRequest> clientHttpSampler() {
+	SamplerFunction<HttpRequest> clientHttpSampler() {
 		return arg -> true;
 	}
 
@@ -165,7 +164,7 @@ class MyDelegateClient implements Client {
 @FeignClient(name = "foo", url = "http://foo")
 interface AnnotatedFeignClient {
 
-	@RequestMapping(value = "/test", method = RequestMethod.GET)
+	@GetMapping("/test")
 	String get();
 
 }

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125delegates/ManuallyCreatedDelegateLoadBalancerFeignClientTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125delegates/ManuallyCreatedDelegateLoadBalancerFeignClientTests.java
@@ -47,8 +47,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -109,12 +108,12 @@ public class ManuallyCreatedDelegateLoadBalancerFeignClientTests {
 class Application {
 
 	@Bean
-	public Client myDelegateClient() {
+	Client myDelegateClient() {
 		return new MyDelegateClient();
 	}
 
 	@Bean
-	public AnnotatedFeignClient annotatedFeignClient(Client client, Decoder decoder,
+	AnnotatedFeignClient annotatedFeignClient(Client client, Decoder decoder,
 			Encoder encoder, Contract contract) {
 		return Feign.builder().client(client).encoder(encoder).decoder(decoder)
 				.contract(contract).target(new HardCodedTarget<>(
@@ -122,18 +121,18 @@ class Application {
 	}
 
 	@Bean
-	public Sampler defaultSampler() {
+	Sampler defaultSampler() {
 		return Sampler.ALWAYS_SAMPLE;
 	}
 
 	@Bean
-	public SpanHandler testSpanHandler() {
+	SpanHandler testSpanHandler() {
 		return new TestSpanHandler();
 	}
 
 	@Bean(name = HttpClientSampler.NAME)
 	@HttpClientSampler
-	public SamplerFunction<HttpRequest> clientHttpSampler() {
+	SamplerFunction<HttpRequest> clientHttpSampler() {
 		return arg -> true;
 	}
 
@@ -161,7 +160,7 @@ class MyDelegateClient implements Client {
 @FeignClient(name = "foo", url = "http://foo")
 interface AnnotatedFeignClient {
 
-	@RequestMapping(value = "/test", method = RequestMethod.GET)
+	@GetMapping("/test")
 	String get();
 
 }

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue307/Issue307Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue307/Issue307Tests.java
@@ -34,17 +34,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
 @FeignClient("participants")
 interface ParticipantsClient {
 
-	@RequestMapping(method = RequestMethod.GET, value = "/races/{raceId}")
-	List<Object> getParticipants(@PathVariable("raceId") String raceId);
+	@GetMapping("/races/{raceId}")
+	List<Object> getParticipants(@PathVariable String raceId);
 
 }
 
@@ -80,22 +79,22 @@ class SleuthSampleApplication {
 	private ParticipantsBean participantsBean;
 
 	@Bean
-	public RestTemplate getRestTemplate() {
+	RestTemplate getRestTemplate() {
 		return new RestTemplate();
 	}
 
 	@Bean
-	public Sampler defaultSampler() {
+	Sampler defaultSampler() {
 		return Sampler.ALWAYS_SAMPLE;
 	}
 
-	@RequestMapping("/")
+	@GetMapping("/")
 	public String home() {
 		LOG.info("you called home");
 		return "Hello World";
 	}
 
-	@RequestMapping("/callhome")
+	@GetMapping("/callhome")
 	public String callHome() {
 		LOG.info("calling home");
 		return this.restTemplate.getForObject("http://localhost:" + port(), String.class);

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue362/Issue362Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue362/Issue362Tests.java
@@ -47,6 +47,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -59,10 +60,10 @@ import static org.assertj.core.api.BDDAssertions.then;
 		configuration = CustomConfig.class)
 interface MyFeignClient {
 
-	@RequestMapping("/service/ok")
+	@GetMapping("/service/ok")
 	String ok();
 
-	@RequestMapping("/service/not-ok")
+	@GetMapping("/service/not-ok")
 	String exp();
 
 }
@@ -138,32 +139,32 @@ public class Issue362Tests {
 class Application {
 
 	@Bean
-	public ServiceTestController serviceTestController() {
+	ServiceTestController serviceTestController() {
 		return new ServiceTestController();
 	}
 
 	@Bean
-	public SleuthTestController sleuthTestController() {
+	SleuthTestController sleuthTestController() {
 		return new SleuthTestController();
 	}
 
 	@Bean
-	public Logger.Level feignLoggerLevel() {
+	Logger.Level feignLoggerLevel() {
 		return Logger.Level.FULL;
 	}
 
 	@Bean
-	public Sampler defaultSampler() {
+	Sampler defaultSampler() {
 		return Sampler.ALWAYS_SAMPLE;
 	}
 
 	@Bean
-	public FeignComponentAsserter testHolder() {
+	FeignComponentAsserter testHolder() {
 		return new FeignComponentAsserter();
 	}
 
 	@Bean
-	public SpanHandler testSpanHandler() {
+	SpanHandler testSpanHandler() {
 		return new TestSpanHandler();
 	}
 
@@ -179,17 +180,17 @@ class FeignComponentAsserter {
 class CustomConfig {
 
 	@Bean
-	public ErrorDecoder errorDecoder(FeignComponentAsserter feignComponentAsserter) {
+	ErrorDecoder errorDecoder(FeignComponentAsserter feignComponentAsserter) {
 		return new CustomErrorDecoder(feignComponentAsserter);
 	}
 
 	@Bean
-	public Retryer retryer() {
+	Retryer retryer() {
 		return new Retryer.Default();
 	}
 
 	@Bean
-	public Client client(FeignComponentAsserter feignComponentAsserter) {
+	Client client(FeignComponentAsserter feignComponentAsserter) {
 		return new CustomClient(feignComponentAsserter);
 	}
 
@@ -239,12 +240,12 @@ class CustomConfig {
 @RequestMapping(path = "/service")
 class ServiceTestController {
 
-	@RequestMapping("/ok")
+	@GetMapping("/ok")
 	public String ok() throws InterruptedException, ExecutionException {
 		return "I'm OK";
 	}
 
-	@RequestMapping("/not-ok")
+	@GetMapping("/not-ok")
 	@ResponseStatus(HttpStatus.CONFLICT)
 	public String notOk() throws InterruptedException, ExecutionException {
 		return "Not OK";
@@ -259,12 +260,12 @@ class SleuthTestController {
 	@Autowired
 	private MyFeignClient myFeignClient;
 
-	@RequestMapping("/test-ok")
+	@GetMapping("/test-ok")
 	public String ok() throws InterruptedException, ExecutionException {
 		return this.myFeignClient.ok();
 	}
 
-	@RequestMapping("/test-not-ok")
+	@GetMapping("/test-not-ok")
 	public String notOk() throws InterruptedException, ExecutionException {
 		return this.myFeignClient.exp();
 	}

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue393/Issue393Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue393/Issue393Tests.java
@@ -36,9 +36,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
@@ -47,8 +46,8 @@ import static org.assertj.core.api.BDDAssertions.then;
 @FeignClient(name = "no-name", url = "http://localhost:9978")
 interface MyNameRemote {
 
-	@RequestMapping(value = "/name/{id}", method = RequestMethod.GET)
-	String getName(@PathVariable("id") String id);
+	@GetMapping("/name/{id}")
+	String getName(@PathVariable String id);
 
 }
 
@@ -100,28 +99,28 @@ public class Issue393Tests {
 class Application {
 
 	@Bean
-	public DemoController demoController(MyNameRemote myNameRemote) {
+	DemoController demoController(MyNameRemote myNameRemote) {
 		return new DemoController(myNameRemote);
 	}
 
 	// issue #513
 	@Bean
-	public OkHttpClient myOkHttpClient() {
+	OkHttpClient myOkHttpClient() {
 		return new OkHttpClient();
 	}
 
 	@Bean
-	public feign.Logger.Level feignLoggerLevel() {
+	feign.Logger.Level feignLoggerLevel() {
 		return feign.Logger.Level.BASIC;
 	}
 
 	@Bean
-	public Sampler defaultSampler() {
+	Sampler defaultSampler() {
 		return Sampler.ALWAYS_SAMPLE;
 	}
 
 	@Bean
-	public SpanHandler testSpanHandler() {
+	SpanHandler testSpanHandler() {
 		return new TestSpanHandler();
 	}
 
@@ -136,13 +135,13 @@ class DemoController {
 		this.myNameRemote = myNameRemote;
 	}
 
-	@RequestMapping("/hello/{name}")
-	public String getHello(@PathVariable("name") String name) {
+	@GetMapping("/hello/{name}")
+	public String getHello(@PathVariable String name) {
 		return this.myNameRemote.getName(name) + " foo";
 	}
 
-	@RequestMapping("/name/{name}")
-	public String getName(@PathVariable("name") String name) {
+	@GetMapping("/name/{name}")
+	public String getName(@PathVariable String name) {
 		return name;
 	}
 

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue502/Issue502Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue502/Issue502Tests.java
@@ -39,15 +39,14 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.cloud.sleuth.instrument.web.HttpClientSampler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
 @FeignClient(name = "foo", url = "http://foo")
 interface MyNameRemote {
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
+	@GetMapping("/")
 	String get();
 
 }
@@ -92,23 +91,23 @@ public class Issue502Tests {
 class Application {
 
 	@Bean
-	public Client client() {
+	Client client() {
 		return new MyClient();
 	}
 
 	@Bean
-	public Sampler defaultSampler() {
+	Sampler defaultSampler() {
 		return Sampler.ALWAYS_SAMPLE;
 	}
 
 	@Bean
-	public SpanHandler testSpanHandler() {
+	SpanHandler testSpanHandler() {
 		return new TestSpanHandler();
 	}
 
 	@Bean(name = HttpClientSampler.NAME)
 	@HttpClientSampler
-	public SamplerFunction<HttpRequest> clientHttpSampler() {
+	SamplerFunction<HttpRequest> clientHttpSampler() {
 		return arg -> true;
 	}
 

--- a/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/ITTracingChannelInterceptorTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/ITTracingChannelInterceptorTests.java
@@ -180,7 +180,7 @@ public class ITTracingChannelInterceptorTests implements MessageHandler {
 		}
 
 		@Bean
-		public MessagingTemplate messagingTemplate() {
+		MessagingTemplate messagingTemplate() {
 			return new MessagingTemplate(directChannel());
 		}
 

--- a/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceContextPropagationChannelInterceptorTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceContextPropagationChannelInterceptorTests.java
@@ -96,7 +96,7 @@ public class TraceContextPropagationChannelInterceptorTests {
 	static class App {
 
 		@Bean
-		public QueueChannel channel() {
+		QueueChannel channel() {
 			return new QueueChannel();
 		}
 

--- a/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/issues/issue_943/HelloWorldRestController.java
+++ b/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/issues/issue_943/HelloWorldRestController.java
@@ -28,8 +28,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -41,7 +40,7 @@ public class HelloWorldRestController {
 	@Autowired
 	private ApplicationContext applicationContext;
 
-	@RequestMapping(path = "getHelloWorldMessage", method = RequestMethod.GET,
+	@GetMapping("getHelloWorldMessage",
 			produces = MediaType.TEXT_PLAIN_VALUE)
 	public ResponseEntity<String> getHelloWorld() throws Exception {
 

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceCustomFilterResponseInjectorTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceCustomFilterResponseInjectorTests.java
@@ -44,8 +44,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.filter.GenericFilterBean;
@@ -112,7 +112,7 @@ public class TraceCustomFilterResponseInjectorTests {
 		}
 
 		@Bean
-		public RestTemplate restTemplate() {
+		RestTemplate restTemplate() {
 			return new RestTemplate();
 		}
 
@@ -147,7 +147,7 @@ public class TraceCustomFilterResponseInjectorTests {
 	@RestController
 	static class CustomRestController {
 
-		@RequestMapping("/headers")
+		@GetMapping("/headers")
 		public Map<String, String> headers(@RequestHeader HttpHeaders headers) {
 			Map<String, String> map = new HashMap<>();
 			for (String key : headers.keySet()) {

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
@@ -57,7 +57,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.filter.GenericFilterBean;
@@ -332,19 +332,19 @@ public class TraceFilterIntegrationTests extends AbstractMvcIntegrationTest {
 			@Autowired
 			private Tracer tracer;
 
-			@RequestMapping("/ping")
+			@GetMapping("/ping")
 			public String ping() {
 				log.info("ping");
 				span = this.tracer.currentSpan();
 				return "ping";
 			}
 
-			@RequestMapping("/throwsException")
+			@GetMapping("/throwsException")
 			public void throwsException() {
 				throw new RuntimeException();
 			}
 
-			@RequestMapping("/deferred")
+			@GetMapping("/deferred")
 			public DeferredResult<String> deferredMethod() {
 				log.info("deferred");
 				span = this.tracer.currentSpan();
@@ -354,7 +354,7 @@ public class TraceFilterIntegrationTests extends AbstractMvcIntegrationTest {
 				return result;
 			}
 
-			@RequestMapping("/future")
+			@GetMapping("/future")
 			public CompletableFuture<String> future() {
 				log.info("future");
 				return CompletableFuture.completedFuture("ping");

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterWebIntegrationTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterWebIntegrationTests.java
@@ -54,8 +54,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.DefaultResponseErrorHandler;
@@ -276,7 +275,7 @@ public class TraceFilterWebIntegrationTests {
 
 		private static final Log log = LogFactory.getLog(GoodController.class);
 
-		@RequestMapping("/good")
+		@GetMapping("/good")
 		public String beGood() {
 			log.info("Good!");
 			return "good";
@@ -287,12 +286,11 @@ public class TraceFilterWebIntegrationTests {
 	@RestController
 	public static class NullParameterController {
 
-		@RequestMapping("/null-parameter")
+		@GetMapping("/null-parameter")
 		@ContinueSpan
 		public String nullParameter(
-				@SpanTag(key = "foo", expression = "(#root?:1000)+1") @RequestParam(
-						value = "bar", required = false) Integer param) {
-			return "ok param=" + param;
+				@SpanTag(key = "foo", expression = "(#root?:1000)+1") @RequestParam(required = false) Integer bar) {
+			return "ok param=" + bar;
 		}
 
 	}
@@ -303,13 +301,13 @@ public class TraceFilterWebIntegrationTests {
 		private static final Log log = LogFactory
 				.getLog(ExceptionThrowingController.class);
 
-		@RequestMapping("/")
+		@GetMapping("/")
 		public void throwException() {
 			log.info("Throws exception");
 			throw new RuntimeException("Throwing exception");
 		}
 
-		@RequestMapping(path = "/test_bad_request", method = RequestMethod.GET)
+		@GetMapping("/test_bad_request")
 		public ResponseEntity<?> processFail() {
 			log.info("Test bad request");
 			return ResponseEntity.badRequest().build();

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/RestTemplateTraceAspectIntegrationTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/RestTemplateTraceAspectIntegrationTests.java
@@ -46,9 +46,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.AsyncRestTemplate;
 import org.springframework.web.client.RestTemplate;
@@ -193,7 +192,7 @@ public class RestTemplateTraceAspectIntegrationTests {
 	public static class Config {
 
 		@Bean
-		public RestTemplate restTemplate() {
+		RestTemplate restTemplate() {
 			return new RestTemplate();
 		}
 
@@ -203,7 +202,7 @@ public class RestTemplateTraceAspectIntegrationTests {
 		}
 
 		@Bean
-		public AsyncRestTemplate asyncRestTemplate(Tracing tracing) {
+		AsyncRestTemplate asyncRestTemplate(Tracing tracing) {
 			AsyncRestTemplate asyncRestTemplate = new AsyncRestTemplate();
 			asyncRestTemplate.setInterceptors(Collections.singletonList(
 					TracingAsyncClientHttpRequestInterceptor.create(tracing)));
@@ -238,19 +237,19 @@ public class RestTemplateTraceAspectIntegrationTests {
 			this.traceId = null;
 		}
 
-		@RequestMapping(value = "/issue1047_end", method = RequestMethod.GET,
+		@GetMapping("/issue1047_end",
 				produces = MediaType.TEXT_PLAIN_VALUE)
 		public String issue1047() {
 			return "should_filter_out_this_endpoint";
 		}
 
-		@RequestMapping(value = "/issue1047_start", method = RequestMethod.GET,
+		@GetMapping("/issue1047_start",
 				produces = MediaType.TEXT_PLAIN_VALUE)
 		public String issue1047Start() {
 			return callAndReturnIssue1047();
 		}
 
-		@RequestMapping(value = "/", method = RequestMethod.GET,
+		@GetMapping("/",
 				produces = MediaType.TEXT_PLAIN_VALUE)
 		public String home(
 				@RequestHeader(value = "X-B3-SpanId", required = false) String traceId) {
@@ -258,7 +257,7 @@ public class RestTemplateTraceAspectIntegrationTests {
 			return "trace=" + this.getTraceId();
 		}
 
-		@RequestMapping(value = "/customTag", method = RequestMethod.GET,
+		@GetMapping("/customTag",
 				produces = MediaType.TEXT_PLAIN_VALUE)
 		public String customTag(
 				@RequestHeader(value = "X-B3-TraceId", required = false) String traceId) {
@@ -266,20 +265,20 @@ public class RestTemplateTraceAspectIntegrationTests {
 			return "trace=" + this.getTraceId();
 		}
 
-		@RequestMapping(value = "/asyncRestTemplate", method = RequestMethod.GET,
+		@GetMapping("/asyncRestTemplate",
 				produces = MediaType.TEXT_PLAIN_VALUE)
 		public String asyncRestTemplate()
 				throws ExecutionException, InterruptedException {
 			return callViaAsyncRestTemplateAndReturnOk();
 		}
 
-		@RequestMapping(value = "/syncPing", method = RequestMethod.GET,
+		@GetMapping("/syncPing",
 				produces = MediaType.TEXT_PLAIN_VALUE)
 		public String syncPing() {
 			return callAndReturnOk();
 		}
 
-		@RequestMapping(value = "/callablePing", method = RequestMethod.GET,
+		@GetMapping("/callablePing",
 				produces = MediaType.TEXT_PLAIN_VALUE)
 		public Callable<String> asyncPing() {
 			return new Callable<String>() {
@@ -290,7 +289,7 @@ public class RestTemplateTraceAspectIntegrationTests {
 			};
 		}
 
-		@RequestMapping(value = "/webAsyncTaskPing", method = RequestMethod.GET,
+		@GetMapping("/webAsyncTaskPing",
 				produces = MediaType.TEXT_PLAIN_VALUE)
 		public WebAsyncTask<String> webAsyncTaskPing() {
 			return new WebAsyncTask<>(new Callable<String>() {

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfigurationTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfigurationTests.java
@@ -40,7 +40,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.AsyncRestTemplate;
 
@@ -158,13 +158,13 @@ public class TraceWebAsyncClientAutoConfigurationTests {
 	@RestController
 	public static class MyController {
 
-		@RequestMapping("/foo")
+		@GetMapping("/foo")
 		String foo() throws Exception {
 			Thread.sleep(100);
 			return "foo";
 		}
 
-		@RequestMapping("/blowsup")
+		@GetMapping("/blowsup")
 		String blowsup() throws Exception {
 			Thread.sleep(100);
 			throw new RuntimeException("boom");

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exceptionresolver/Issue585Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exceptionresolver/Issue585Tests.java
@@ -41,8 +41,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -98,7 +97,7 @@ class TestController {
 
 	private final static Logger logger = LoggerFactory.getLogger(TestController.class);
 
-	@RequestMapping(value = "sleuthtest", method = RequestMethod.GET)
+	@GetMapping("sleuthtest")
 	public ResponseEntity<String> testSleuth(@RequestParam String greeting) {
 		if (greeting.equalsIgnoreCase("hello")) {
 			return new ResponseEntity<>("Hello World", HttpStatus.OK);

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientBraveTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientBraveTests.java
@@ -94,7 +94,7 @@ public class WebClientBraveTests extends ITSpringConfiguredReactorClient {
 		 */
 		@Bean
 		@Order(0)
-		public WebClientCustomizer clientConnectorCustomizer(HttpClient httpClient,
+		WebClientCustomizer clientConnectorCustomizer(HttpClient httpClient,
 				URI baseUrl) {
 			return (builder) -> builder.baseUrl(baseUrl.toString())
 					.clientConnector(new ReactorClientHttpConnector(httpClient));


### PR DESCRIPTION
This demonstrates some simple Spring hygiene recipes, reducing unnecessary public visibility modifiers and replacing the CSRF-injection vulnerable `@RequestMapping` with `@GetMapping`.

This change also demonstrates how Rewrite can respond to non-standard stylistic conventions on a per-project basis, in this case a special import ordering scheme that this project uses:

```yml
---
type: specs.openrewrite.org/v1beta/style
name: io.moderne.spring.style

configure:
  org.openrewrite.java.style.ImportLayoutStyle:
    layout:
      classCountToUseStarImport: 999
      nameCountToUseStarImport: 999
      blocks:
        - import java.*
        - <blank line>
        - import javax.*
        - <blank line>
        - import all other imports
        - <blank line>
        - import org.springframework.*
        - <blank line>
        - import static all other imports
```